### PR TITLE
Allow deleting individual courses.

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -123,7 +123,7 @@ class App extends React.Component {
 
   handleDisplayChange(e) {
     const index = parseInt(e.target.id.split("_")[1]);
-    let newCourseInfoList = this.state.courseInfoList;
+    let newCourseInfoList = [...this.state.courseInfoList];
     const newCourseInfo = CourseInfo.changeIsDisplayed(newCourseInfoList[index], e.target.checked);
     newCourseInfoList[index] = newCourseInfo;
     this.setState({ courseInfoList: newCourseInfoList });
@@ -132,6 +132,18 @@ class App extends React.Component {
   addCourse(courseInfo) {
     this.setState(state => ({
       courseInfoList: state.courseInfoList.concat(courseInfo),
+    }));
+  }
+
+  deleteCourse(deleteIndex) {
+    if (this.state.courseInfoList.length <= 1) {
+      this.clearSchedule();
+      return;
+    }
+    this.setState(state => ({
+      courseInfoList: state.courseInfoList.filter((_, index) => {
+        return index !== deleteIndex;
+      }),
     }));
   }
 
@@ -160,6 +172,7 @@ class App extends React.Component {
           days={courseInfo.days}
           isDisplayed={courseInfo.isDisplayed}
           handleDisplayChange={this.handleDisplayChange}
+          handleDelete={() => {this.deleteCourse(i)}}
         />
       );
     }

--- a/src/components/courseTable.jsx
+++ b/src/components/courseTable.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import DaysOfTheWeek, { Checkbox } from './daysOfTheWeek';
+import IconButton from '@material-ui/core/IconButton';
+import DeleteTwoToneIcon from '@material-ui/icons/DeleteTwoTone';
 
 export default class CourseTable extends React.Component {
   constructor(props) {
@@ -21,12 +23,13 @@ export default class CourseTable extends React.Component {
               <th>Start Time</th>
               <th>End Time</th>
               <th>Days</th>
+              <th></th>  {/*Delete button column.*/}
             </tr>
           </thead>
           <tbody>
             {this.props.courseRows}
             <tr className="course_row">
-              <td colSpan="6">Credits: {this.props.numCredits}</td>
+              <td colSpan="7">Credits: {this.props.numCredits}</td>
             </tr>
           </tbody>
         </table>
@@ -61,6 +64,12 @@ export class CourseRow extends React.Component {
                            days={this.props.days}
                            disabled={true}
                            handleChange={this.handleDaysChange} /></td>
+        <td>
+          <IconButton onClick={this.props.handleDelete}
+                      style={{ 'padding': '1px' }}>
+            <DeleteTwoToneIcon fontSize='small'/>
+          </IconButton>
+        </td>
       </tr>
     );
   }


### PR DESCRIPTION
This change adds a small delete icon next to each course row in the course table. If all courses in a saved schedule are deleted, we clear the current session as if the user cleared the entire schedule.

One small but strange consequence: some calendar colors will change with deletions. This is because colors aren't assigned to specific courses, they're assigned to indices in the list of courses which get modified when courses are deleted. This could probably be improved in the future.